### PR TITLE
Skip a broken test with Pyton 3.5.1

### DIFF
--- a/test_functools.py
+++ b/test_functools.py
@@ -55,7 +55,7 @@ class TestThrottler(object):
 
 
 class TestMethodCache:
-	bad_vers = '(3, 5, 0) <= sys.version_info < (3, 5, 1)'
+	bad_vers = '(3, 5, 0) <= sys.version_info < (3, 5, 2)'
 	@pytest.mark.skipif(bad_vers, reason="https://bugs.python.org/issue25447")
 	def test_deepcopy(self):
 		"""


### PR DESCRIPTION
It seems that the bugfix isn't in v3.5.1, it still failed on my system.