### PR TITLE
Problems with method_cache on __getitem__ and __getattr__

### DIFF
--- a/test_functools.py
+++ b/test_functools.py
@@ -72,3 +72,31 @@ class TestMethodCache:
 		copy.deepcopy(ob)
 		ob.method(1)
 		copy.deepcopy(ob)
+
+	def test_magic_methods(self):
+		"""
+		Test method_cache with __getitem__ and __getattr__.
+		"""
+		class ClassUnderTest:
+			getitem_calls = 0
+			getattr_calls = 0
+
+			@method_cache
+			def __getitem__(self, item):
+				self.getitem_calls += 1
+				return item
+
+			@method_cache
+			def __getattr__(self, name):
+				self.getattr_calls += 1
+				return name
+
+		ob = ClassUnderTest()
+
+		# __getitem__
+		_ = ob[1] + ob[1]
+		assert ob.getitem_calls == 1
+
+		# __getattr__
+		_ = ob.one + ob.one
+		assert ob.getattr_calls == 1


### PR DESCRIPTION
Using `method_cache` on the `__getitem__` and `__getattr__` magic methods does not work as expected.

On python2, `method_cache` on `__getitem__` works fine, but not on `__getattr__`: no cached values are returned.

On python3, `method_cache` fails to return cached values on both `__getitem__` and `__getattr__`.

This PR adds a test that tries to highlight the issue. Hopefully a solution to this problem can be found (making this test pass!).

Regards.