### PR TITLE
setup.cfg: more_itertools dropped support for python 2.7 with release 6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ packages = find:
 include_package_data = true
 python_requires = >=2.7
 install_requires =
-	more_itertools
+	more_itertools <  6.0.0; python_version == "2.7"
+	more_itertools >= 6.0.0; python_version >= "3.0"
 	backports.functools_lru_cache >= 1.0.3; python_version == "2.7"
 setup_requires = setuptools_scm >= 1.15.0
 


### PR DESCRIPTION
Fixes https://github.com/jaraco/jaraco.functools/issues/10

Verified that with python 2.7 and 3.6.7, ```pip install --user -e .``` installed the expected compatible version of more-itertools.