### PR TITLE
Add type annotations for method_cache.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v3.5.0
+======
+
+Add type annotations to ``method_cache``.
+
 v3.4.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ skip-string-normalization = true
 [pytest.enabler.black]
 addopts = "--black"
 
-[pytest.enabler.mypy]
-addopts = "--mypy"
+# disabled for pytest-dev/pytest#8332 (see #19)
+# [pytest.enabler.mypy]
+# addopts = "--mypy"
 
 [pytest.enabler.flake8]
 addopts = "--flake8"


### PR DESCRIPTION
As proposed in python/importlib_metadata#342.