### PR TITLE
remove extraneous runtime dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ include_package_data = true
 python_requires = >=3.8
 install_requires =
 	more_itertools
-	typing_extensions; python_version < "3.11"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This is only imported by the typing stubs, not by the actual library.