### PR TITLE
Remove unnecessary `__future__` import

### DIFF
--- a/jaraco/functools/__init__.py
+++ b/jaraco/functools/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections.abc
 import functools
 import inspect


### PR DESCRIPTION
Remove unnecessary `from __future__ import annotations` line.