### PR TITLE
Remove deprecated `call_aside` from __init__.pyi

### DIFF
--- a/jaraco/functools/__init__.pyi
+++ b/jaraco/functools/__init__.pyi
@@ -74,9 +74,6 @@ def result_invoke(
 def invoke(
     f: Callable[_P, _R], /, *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[_P, _R]: ...
-def call_aside(
-    f: Callable[_P, _R], *args: _P.args, **kwargs: _P.kwargs
-) -> Callable[_P, _R]: ...
 
 class Throttler(Generic[_R]):
     last_called: float


### PR DESCRIPTION
A followup to 9930bc1.