### PR TITLE
Added missing `splat` in stubs

### DIFF
--- a/jaraco/functools/__init__.py
+++ b/jaraco/functools/__init__.py
@@ -8,7 +8,6 @@ import operator
 import time
 import types
 import warnings
-
 from typing import Callable, TypeVar
 
 import more_itertools
@@ -488,7 +487,7 @@ def save_method_args(method):
     >>> my_ob._saved_method.args
     ()
     """
-    args_and_kwargs = collections.namedtuple('args_and_kwargs', 'args kwargs')
+    args_and_kwargs = collections.namedtuple('args_and_kwargs', 'args kwargs')  # noqa: PYI024 # This is internal and we're using a stub for public types
 
     @functools.wraps(method)
     def wrapper(self, /, *args, **kwargs):

--- a/jaraco/functools/__init__.pyi
+++ b/jaraco/functools/__init__.pyi
@@ -1,7 +1,6 @@
 from collections.abc import Callable, Hashable, Iterator
 from functools import partial
 from operator import methodcaller
-import sys
 from typing import (
     Any,
     Generic,
@@ -10,14 +9,12 @@ from typing import (
     overload,
 )
 
-if sys.version_info >= (3, 10):
-    from typing import Concatenate, ParamSpec
-else:
-    from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import Concatenate, ParamSpec, TypeVarTuple, Unpack
 
 _P = ParamSpec('_P')
 _R = TypeVar('_R')
 _T = TypeVar('_T')
+_Ts = TypeVarTuple('_Ts')
 _R1 = TypeVar('_R1')
 _R2 = TypeVar('_R2')
 _V = TypeVar('_V')
@@ -95,12 +92,12 @@ method_caller: Callable[..., methodcaller]
 def retry_call(
     func: Callable[..., _R],
     cleanup: Callable[..., None] = ...,
-    retries: int | float = ...,
+    retries: float = ...,
     trap: type[BaseException] | tuple[type[BaseException], ...] = ...,
 ) -> _R: ...
 def retry(
     cleanup: Callable[..., None] = ...,
-    retries: int | float = ...,
+    retries: float = ...,
     trap: type[BaseException] | tuple[type[BaseException], ...] = ...,
 ) -> Callable[[Callable[..., _R]], Callable[..., _R]]: ...
 def print_yielded(func: Callable[_P, Iterator[Any]]) -> Callable[_P, None]: ...
@@ -123,3 +120,4 @@ def bypass_when(
 def bypass_unless(
     check: Any,
 ) -> Callable[[Callable[[_T], _R]], Callable[[_T], _T | _R]]: ...
+def splat(func: Callable[[Unpack[_Ts]], _R]) -> Callable[[tuple[Unpack[_Ts]]], _R]: ...

--- a/newsfragments/29.bugfix.rst
+++ b/newsfragments/29.bugfix.rst
@@ -1,0 +1,1 @@
+Added missing `splat` in stubs -- by :user:`Avasam`


### PR DESCRIPTION
This is used in https://github.com/pypa/distutils/blob/efa2eb231c82f6630468ad358cfe4b65a013b690/distutils/_modified.py#L10

Closes #29 