### PR TITLE
Preserve Throttler on class attribute access

### DIFF
--- a/jaraco/functools/__init__.py
+++ b/jaraco/functools/__init__.py
@@ -338,6 +338,8 @@ class Throttler:
         self.last_called = time.time()
 
     def __get__(self, obj, owner=None):
+        if obj is None:
+            return self
         return first_invoke(self._wait, functools.partial(self.func, obj))
 
 

--- a/newsfragments/+throttler-class-access.bugfix.rst
+++ b/newsfragments/+throttler-class-access.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve ``Throttler`` when accessed on a class, allowing unbound method calls with an explicit instance.

--- a/test_throttler.py
+++ b/test_throttler.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from jaraco.functools import Throttler
+
+
+class Example:
+    @Throttler
+    def method(self, value: int) -> tuple[Example, int]:
+        return self, value
+
+
+def test_class_access_preserves_descriptor() -> None:
+    assert Example.method is vars(Example)['method']
+
+
+def test_unbound_method_call() -> None:
+    instance = Example()
+    assert Example.method(instance, value=42) == (instance, 42)
+
+
+def test_bound_method_call() -> None:
+    instance = Example()
+    assert instance.method(value=42) == (instance, 42)


### PR DESCRIPTION
Accessing a `Throttler`-decorated method through its class currently binds `None` as the instance. `Example.method(instance, value=42)` therefore passes an extra positional argument and fails, although calling the bound method works.

Return the descriptor itself when `obj is None`, preserving normal unbound method calls and class-level access to its configuration. Tests cover class access, an explicit-instance call, and the existing bound call. Includes a news fragment.

Validation: the two class-access regressions fail before the change. `pytest -p no:ruff` passes 47 checks with 2 expected failures and 100% coverage, including mypy and doctests. Changed files pass formatting. Full `tox -e py` reports three Ruff failures in unchanged code/configuration; those were separately reproduced on baseline HEAD.
